### PR TITLE
fix custom repo url persistence and small typos in ui labels

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/githubissues/GitHubIssueAction.java
+++ b/src/main/java/org/jenkinsci/plugins/githubissues/GitHubIssueAction.java
@@ -9,7 +9,6 @@
 package org.jenkinsci.plugins.githubissues;
 
 import hudson.model.BuildBadgeAction;
-import hudson.model.Result;
 import org.jenkinsci.plugins.github.util.XSSApi;
 import org.kohsuke.github.GHIssue;
 

--- a/src/main/java/org/jenkinsci/plugins/githubissues/GitHubIssueNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubissues/GitHubIssueNotifier.java
@@ -40,8 +40,8 @@ public class GitHubIssueNotifier extends Notifier implements SimpleBuildStep {
     private String issueBody;
     private String issueLabel;
     private String issueRepo;
-    private boolean issueReopen = true;
-    private boolean issueAppend = true;
+    private boolean issueReopen = false;
+    private boolean issueAppend = false;
 
     /**
      * Initialises the {@link GitHubIssueNotifier} instance.
@@ -83,8 +83,8 @@ public class GitHubIssueNotifier extends Notifier implements SimpleBuildStep {
         if (StringUtils.isNotBlank(this.issueRepo)) {
             repoUrl = this.issueRepo;
         } else {
-            GithubProjectProperty foo = job.getProperty(GithubProjectProperty.class);
-            repoUrl = foo.getProjectUrlStr();
+            GithubProjectProperty project = job.getProperty(GithubProjectProperty.class);
+            repoUrl = project.getProjectUrlStr();
         }
         GitHubRepositoryName repoName = GitHubRepositoryName.create(repoUrl);
         if (repoName == null) {
@@ -211,12 +211,29 @@ public class GitHubIssueNotifier extends Notifier implements SimpleBuildStep {
         return issueLabel;
     }
 
+    /**
+     * Flag to switch between reopening an existing issue or
+     * creating a new one.
+     * @return true if an existing issue should be reopened.
+     */
     public boolean isIssueReopen() {
         return issueReopen;
     }
 
+    /**
+     * Flag to switch between commenting an issue on continuous failure or just on first failure.
+     * @return true if an issue should be commented continuously on feach failures.
+     */
     public boolean isIssueAppend() {
         return issueAppend;
+    }
+
+    /**
+     * An alternative repo to report the issues.
+     * @return the url of the issue repo if set
+     */
+    public String getIssueRepo() {
+        return issueRepo;
     }
 
     @Extension

--- a/src/main/resources/org/jenkinsci/plugins/githubissues/GithubIssueNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/githubissues/GithubIssueNotifier/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:block>
-        <f:optionalBlock name="useCustomTemplate" inline="true" title="Customize issue template" checked="${instance.useCustomTemplate}">
+        <f:optionalBlock name="advancedSettings" inline="true" title="Advanced settings">
             <f:entry title="Issue Title Template" field="issueTitle">
                 <f:textbox />
             </f:entry>
@@ -11,10 +11,10 @@
             <f:entry title="Issue Label" field="issueLabel">
                 <f:textbox />
             </f:entry>
-            <f:entry title="Reopen issue" field="issueReopen">
+            <f:entry title="Reopen an existing issue" field="issueReopen">
                  <f:checkbox default="true"/>
             </f:entry>
-            <f:entry title="Append Failures on next job to existing issue" field="issueAppend">
+            <f:entry title="Append comment on failure " field="issueAppend">
                  <f:checkbox default="true"/>
             </f:entry>
             <f:entry title="Issue Repository" field="issueRepo">


### PR DESCRIPTION
This pr fixes the loading of a configured custom repo url in the ui. The custom repo url was persisted but not displayed correctly.
Also some small typos are corrected. 